### PR TITLE
Adjust UI controls for HiDiffusion setting

### DIFF
--- a/javascript/generationParams.js
+++ b/javascript/generationParams.js
@@ -1,15 +1,12 @@
-// attaches listeners to the txt2img and img2img galleries to update displayed generation param text when the image changes
-
 function attachGalleryListeners(tabName) {
   const gallery = gradioApp().querySelector(`#${tabName}_gallery`);
   if (!gallery) return null;
   gallery.addEventListener('click', () => {
-    // log('galleryItemSelected:', tabName);
     const btn = gradioApp().getElementById(`${tabName}_generation_info_button`);
     if (btn) btn.click();
   });
   gallery?.addEventListener('keydown', (e) => {
-    if (e.keyCode === 37 || e.keyCode === 39) gradioApp().getElementById(`${tabName}_generation_info_button`).click(); // left or right arrow
+    if (e.keyCode === 37 || e.keyCode === 39) gradioApp().getElementById(`${tabName}_generation_info_button`).click();
   });
   return gallery;
 }
@@ -38,4 +35,16 @@ async function initiGenerationParams() {
   if (!control_gallery) control_gallery = attachGalleryListeners('control');
   modalObserver.observe(modal, { attributes: true, attributeFilter: ['style'] });
   log('initGenerationParams');
+}
+
+function onCalcResolutionHires(width, height, hr_scale, hr_resize_x, hr_resize_y, hr_upscaler) {
+  const setInactive = (elem, inactive) => elem.classList.toggle('inactive', !!inactive);
+  const hrUpscaleBy = gradioApp().getElementById('txt2img_hr_scale');
+  const hrResizeX = gradioApp().getElementById('txt2img_hr_resize_x');
+  const hrResizeY = gradioApp().getElementById('txt2img_hr_resize_y');
+  setInactive(hrUpscaleBy, hr_resize_x > 0 || hr_resize_y > 0);
+  setInactive(hrResizeX, hr_resize_x === 0);
+  setInactive(hrResizeY, hr_resize_y === 0);
+  updateIncrementSize();
+  return [width, height, hr_scale, hr_resize_x, hr_resize_y, hr_upscaler];
 }

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -536,3 +536,14 @@ async function reconnectUI() {
   sd_model_observer.observe(sd_model, { attributes: true, childList: true, subtree: true });
   log('reconnectUI');
 }
+
+function updateIncrementSize() {
+  const hiDiffusionEnabled = gradioApp().getElementById('hidiffusion_enabled').checked;
+  const incrementSize = hiDiffusionEnabled ? 128 : 8;
+  const widthControl = gradioApp().getElementById('txt2img_width');
+  const heightControl = gradioApp().getElementById('txt2img_height');
+  if (widthControl) widthControl.step = incrementSize;
+  if (heightControl) heightControl.step = incrementSize;
+}
+
+document.getElementById('hidiffusion_enabled').addEventListener('change', updateIncrementSize);


### PR DESCRIPTION
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Aptronymist/automatic/pull/2?shareId=7bbd1375-3c2a-47aa-8a63-5788eef626e5).

## Summary by Sourcery

Adjust the behavior of the width and height control for HiDiffusion setting. When HiDiffusion is enabled, the increment step for width and height is set to 128; otherwise, it is set to 8.

New Features:
- Add `onCalcResolutionHires` function to update the active state of HiRes resolution controls based on user input.

Enhancements:
- Inactive HiRes upscale controls when resize controls are used.
- Update width and height increment sizes when HiDiffusion is toggled.